### PR TITLE
WIP dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 npm-debug.log
 firebase-debug.log
+package-lock.json

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,7 @@
       </div>
     </main>
     <footer class="mw8 center relative">
+    <footer class="mw8 cf center relative">
       <p class="gray">
         This site is not endorsed by or affiliated with Crunchyroll. <br />
         Created by <a href="https://twitter.com/zachbruggeman" target="_blank" rel="noopener">Zach Bruggeman</a>. <a href="https://github.com/remixz/umi" target="_blank" rel="noopener">View source on GitHub</a>. <br />

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div id="app"  :class="darkTheme ? 'bg-black' :'bg-white'">
     <umi-header v-if="routeName !== 'login'" />
     <div class="fixed top-0 right-0 left-0 center tc pa3 z-max fw6 bg-yellow box-shadow-umi guest-message" :class="{active: guestMessage}">
       You can't leave the player as a guest while in a room that's controlled by the host.
@@ -17,7 +17,7 @@
       </div>
     </div>
     <router-view v-if="routeName === 'login'"></router-view>
-    <main class="bg-white center pv1 ph3 mv3" v-else>
+    <main class="center pv1 ph3 mv3" :class="darkTheme ? 'bg-black' :'bg-white'" v-else>
       <router-view v-if="loaded"></router-view>
       <div v-else-if="error">
         <img src="https://my.mixtape.moe/gazrbv.gif" class="fl pr3">
@@ -32,7 +32,6 @@
         <i class="fa fa-circle-o-notch fa-spin fa-3x silver mt5"></i>
       </div>
     </main>
-    <footer class="mw8 center relative">
     <footer class="mw8 cf center relative">
       <p class="gray">
         This site is not endorsed by or affiliated with Crunchyroll. <br />
@@ -86,6 +85,9 @@ export default {
     },
     guestMessage () {
       return this.$store.state.guestMessage
+    },
+    darkTheme () {
+      return this.$store.state.darkTheme
     }
   },
   methods: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app"  :class="darkTheme ? 'bg-black' :'bg-white'">
+  <div id="app"  :class="darkTheme ? ['bg-black','gray'] :'bg-white'">
     <umi-header v-if="routeName !== 'login'" />
     <div class="fixed top-0 right-0 left-0 center tc pa3 z-max fw6 bg-yellow box-shadow-umi guest-message" :class="{active: guestMessage}">
       You can't leave the player as a guest while in a room that's controlled by the host.
@@ -17,7 +17,7 @@
       </div>
     </div>
     <router-view v-if="routeName === 'login'"></router-view>
-    <main class="center pv1 ph3 mv3" :class="darkTheme ? 'bg-black' :'bg-white'" v-else>
+    <main class="center pv1 ph3" :class="darkTheme ? 'bg-black' :'bg-white'" v-else>
       <router-view v-if="loaded"></router-view>
       <div v-else-if="error">
         <img src="https://my.mixtape.moe/gazrbv.gif" class="fl pr3">
@@ -152,7 +152,7 @@ export default {
   main {
     width: 64rem;
     min-height: calc(100vh - 5rem);
-    margin-top: 77px;
+    padding-top: 77px;
   }
 
   .notification {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="fixed top-0 w-100" :class="[lights ? 'z-3' : 'z-max', {'alt-header': routeName === 'series' || routeName === 'media', 'box-shadow-umi': routeName !== 'media'}]">
+  <header class="fixed top-0 w-100" :class="[lights ? 'z-3' : 'z-max', {'alt-header': routeName === 'series' || routeName === 'media', 'box-shadow-umi': routeName !== 'media'},{'darkTheme':darkTheme}]">
     <div class="header-container center relative">
       <div class="logo-container">
         <router-link to="/" class="db no-underline" exact>
@@ -9,11 +9,11 @@
       </div>
       <div>
         <div class="absolute nav">
-          <router-link to="/queue" class="dark-gray no-underline">
+          <router-link to="/queue" class="no-underline" :class="darkTheme ? 'near-white' : 'dark-gray'">
             <i class="fa fa-th-list v-mid mr2" aria-hidden="true"></i>
             <span class="fw6">Queue</span>
           </router-link>
-          <router-link to="/history" class="dark-gray no-underline">
+          <router-link to="/history" class="no-underline" :class="darkTheme ? 'near-white' : 'dark-gray'">
             <i class="fa fa-history v-mid mr2" aria-hidden="true"></i>
             <span class="fw6">History</span>
           </router-link>
@@ -21,7 +21,7 @@
         <div class="absolute search right-0">
           <span class="fa-stack dib pointer" @click="showTogether" v-if="room !== ''" @mouseover="roomHover = true" @mouseout="roomHover = false">
             <i class="fa fa-circle fa-stack-2x transparent link menu-circle" :class="{active: roomMenu}"></i>
-            <i class="fa fa-users fa-stack-1x dark-gray pointer-events-none"></i>
+            <i class="fa fa-users fa-stack-1x pointer-events-none" :class="darkTheme ? 'near-white' : 'dark-gray'"></i>
           </span>
           <span class="relative fl bg-dark-gray white pa1 tc br2 f7 fw7 nowrap counter" v-if="room !== ''">{{connectedCount}}</span>
           <div v-if="roomMenu" v-on-clickaway="hideTogether" class="absolute bg-white shadow-1 br2 pv2 ph3 together-menu">
@@ -40,7 +40,7 @@
           <search />
           <span class="fa-stack dib pointer" @click="showMenu">
             <i class="fa fa-circle fa-stack-2x transparent link menu-circle" :class="{active: menu}"></i>
-            <i class="fa fa-ellipsis-v fa-stack-1x dark-gray pointer-events-none"></i>
+            <i class="fa fa-ellipsis-v fa-stack-1x pointer-events-none" :class="darkTheme ? 'near-white' : 'dark-gray'"></i>
           </span>
           <div v-if="menu" v-on-clickaway="hideMenu" class="absolute bg-white shadow-1 right-0 br2 pv2 menu">
             <div class="pv2 mh2 fw6 bb mb2 b--gray">
@@ -100,6 +100,9 @@ export default {
     connectedCount () {
       const count = this.$store.state.connectedCount
       return (this.roomHover || this.roomMenu) ? `${count} ${count === 1 ? 'person' : 'people'} connected` : count
+    },
+    darkTheme () {
+      return this.$store.state.darkTheme
     },
     room () {
       return this.$store.state.roomId
@@ -175,6 +178,9 @@ export default {
     transform: translateZ(0); /* hack fix for 1px jitter when a transform happens on the page */
   }
 
+  header.darkTheme {
+    background-color: rgba(60,60,60,0.95);
+  }
   .header-container {
     width: 1024px;
   }

--- a/src/components/MediaItem.vue
+++ b/src/components/MediaItem.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link :to="`/series/${data.series_id}/${id}`" class="black" :class="{'pointer-events-none o-60': isRoomGuest}" v-if="data.available">
-    <div class="media-item dib v-top h-100 mr3 mb2 br2 bg-white" :class="[{'hide-child': !selected}, size]" @click="$emit('click')">
+    <div class="media-item dib v-top h-100 mr3 mb2 br2 " :class="[{'hide-child': !selected}, size, darkTheme ? ['bg-near-black','gray'] :'bg-white']" @click="$emit('click')">
       <div class="relative">
         <img v-if="data.screenshot_image" :src="data.screenshot_image.full_url" class="w-100 image-size br2 br--top">
         <div v-else class="w-100 image-size tc placeholder-image bg-light-gray">
@@ -44,6 +44,9 @@
       },
       isRoomGuest () {
         return this.$store.state.roomConnected && this.$store.state.roomData.hostOnly && !this.$store.getters.isRoomHost
+      },
+      darkTheme () {
+        return this.$store.state.darkTheme
       }
     }
   }

--- a/src/components/MediaItem.vue
+++ b/src/components/MediaItem.vue
@@ -1,6 +1,6 @@
 <template>
-  <router-link :to="`/series/${data.series_id}/${id}`" class="black" :class="{'pointer-events-none o-60': isRoomGuest}" v-if="data.available">
-    <div class="media-item dib v-top h-100 mr3 mb2 br2 " :class="[{'hide-child': !selected}, size, darkTheme ? ['bg-near-black','gray'] :'bg-white']" @click="$emit('click')">
+  <router-link :to="`/series/${data.series_id}/${id}`" :class="[{'pointer-events-none o-60': isRoomGuest}, darkTheme ? 'gray' : 'black']" v-if="data.available">
+    <div class="media-item dib v-top h-100 mr3 mb2 br2 " :class="[{'hide-child': !selected}, size, darkTheme ? 'bg-near-black' :'bg-white']" @click="$emit('click')">
       <div class="relative">
         <img v-if="data.screenshot_image" :src="data.screenshot_image.full_url" class="w-100 image-size br2 br--top">
         <div v-else class="w-100 image-size tc placeholder-image bg-light-gray">

--- a/src/components/QueueItem.vue
+++ b/src/components/QueueItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-link :to="`/series/${data.most_likely_media.series_id}/${data.most_likely_media.media_id}`" class="link black" v-if="data.most_likely_media.available">
+  <router-link :to="`/series/${data.most_likely_media.series_id}/${data.most_likely_media.media_id}`" class="link" :class="darkTheme ? 'gray' : 'black'" v-if="data.most_likely_media.available">
     <div class="w-100 mb2 pa3 cf hide-child br2 ba b--near-white box-shadow-umi">
       <div class="fl w-20 relative">
         <img :src="data.most_likely_media.screenshot_image.thumb_url" class="v-mid image-size">
@@ -17,7 +17,7 @@
       </div>
     </div>
   </router-link>
-  <router-link :to="`/series/${data.most_likely_media.series_id}`" class="link black" v-else>
+  <router-link :to="`/series/${data.most_likely_media.series_id}`" class="link" :class="darkTheme ? 'gray' : 'black'" v-else>
     <div class="bg-near-white w-100 mb2 pa3 cf bb bw2 b--light-gray hide-child">
       <div class="fl w-20 relative">
         <img :src="data.series.landscape_image.thumb_url" class="v-mid image-size">
@@ -47,6 +47,9 @@
         return {
           width: `${Math.min(100, (this.data.most_likely_media.playhead / this.data.most_likely_media.duration) * 100)}%`
         }
+      },
+      darkTheme () {
+        return this.$store.state.darkTheme
       }
     }
   }

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -2,10 +2,11 @@
   <div>
     <div class="dashboard-section">
       <div class="cf bb">
-        <h2 class="fw4 mv0 pb3 fl"><i class="fa fa-play mr1" aria-hidden="true"></i> Continue watching</h2>
+        <h2 class="fw4 mv0 pb3 fl" :class="{'gray': darkTheme}"><i class="fa fa-play mr1" aria-hidden="true"></i> Continue watching</h2>
         <router-link
           to="/history"
-          class="fr link f6 mt1 fw6 ba b--black-20 bg-white bg-animate hover-bg-light-gray black br1 pointer ph2 pv1 tc br2 box-shadow-umi"
+          class="fr link f6 mt1 fw6 ba b--black-20 bg-animate hover-bg-light-gray black br1 pointer ph2 pv1 tc br2 box-shadow-umi"
+          :class="{'bg-dark-gray': darkTheme}"
         >
           View more
         </router-link>
@@ -17,10 +18,11 @@
     </div>
     <div class="dashboard-section">
       <div class="cf bb">
-        <h2 class="fw4 mv0 pb3 fl"><i class="fa fa-th-list mr1" aria-hidden="true"></i> Your queue</h2>
+        <h2 class="fw4 mv0 pb3 fl" :class="{'gray': darkTheme}"><i class="fa fa-th-list mr1" aria-hidden="true"></i> Your queue</h2>
         <router-link
           to="/queue"
-          class="fr link f6 mt1 fw6 ba b--black-20 bg-white bg-animate hover-bg-light-gray black br1 pointer ph2 pv1 tc br2 box-shadow-umi"
+          class="fr link f6 mt1 fw6 ba b--black-20 bg-animate hover-bg-light-gray black br1 pointer ph2 pv1 tc br2 box-shadow-umi"
+          :class="{'bg-dark-gray': darkTheme}"
         >
           View more
         </router-link>
@@ -31,10 +33,10 @@
       <dashboard-loading-section v-else />
     </div>
     <div class="dashboard-section">
-      <h2 class="fw4 mv0 pb3 bb"><i class="fa fa-calendar-o mr1" aria-hidden="true"></i> Latest releases</h2>
+      <h2 class="fw4 mv0 pb3 bb" :class="{'gray': darkTheme}"><i class="fa fa-calendar-o mr1" aria-hidden="true"></i> Latest releases</h2>
       <div v-if="Object.keys(splits).length !== 0">
         <div v-for="(media, title) in splits" :key="title">
-          <h3 class="fw4 near-black pb2 bb b--silver">{{title}}</h3>
+          <h3 class="fw4 near-black pb2 bb b--silver" :class="{'gray': darkTheme}">{{title}}</h3>
           <div class="center">
             <media-item v-for="d in media" :key="d.media_id" :id="d.media_id" :collectionName="d.series_name" size="dashboard" />
           </div>
@@ -92,6 +94,9 @@
         return Object.values(obj)
           .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
           .slice(0, 4)
+      },
+      darkTheme () {
+        return this.$store.state.darkTheme
       }
     },
     methods: {

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="dashboard-section">
       <div class="cf bb">
-        <h2 class="fw4 mv0 pb3 fl" :class="{'gray': darkTheme}"><i class="fa fa-play mr1" aria-hidden="true"></i> Continue watching</h2>
+        <h2 class="fw4 mv0 pb3 fl"><i class="fa fa-play mr1" aria-hidden="true"></i> Continue watching</h2>
         <router-link
           to="/history"
           class="fr link f6 mt1 fw6 ba b--black-20 bg-animate hover-bg-light-gray black br1 pointer ph2 pv1 tc br2 box-shadow-umi"
@@ -18,7 +18,7 @@
     </div>
     <div class="dashboard-section">
       <div class="cf bb">
-        <h2 class="fw4 mv0 pb3 fl" :class="{'gray': darkTheme}"><i class="fa fa-th-list mr1" aria-hidden="true"></i> Your queue</h2>
+        <h2 class="fw4 mv0 pb3 fl" ><i class="fa fa-th-list mr1" aria-hidden="true"></i> Your queue</h2>
         <router-link
           to="/queue"
           class="fr link f6 mt1 fw6 ba b--black-20 bg-animate hover-bg-light-gray black br1 pointer ph2 pv1 tc br2 box-shadow-umi"
@@ -33,10 +33,10 @@
       <dashboard-loading-section v-else />
     </div>
     <div class="dashboard-section">
-      <h2 class="fw4 mv0 pb3 bb" :class="{'gray': darkTheme}"><i class="fa fa-calendar-o mr1" aria-hidden="true"></i> Latest releases</h2>
+      <h2 class="fw4 mv0 pb3 bb" ><i class="fa fa-calendar-o mr1" aria-hidden="true"></i> Latest releases</h2>
       <div v-if="Object.keys(splits).length !== 0">
         <div v-for="(media, title) in splits" :key="title">
-          <h3 class="fw4 near-black pb2 bb b--silver" :class="{'gray': darkTheme}">{{title}}</h3>
+          <h3 class="fw4 near-black pb2 bb b--silver">{{title}}</h3>
           <div class="center">
             <media-item v-for="d in media" :key="d.media_id" :id="d.media_id" :collectionName="d.series_name" size="dashboard" />
           </div>

--- a/src/pages/History.vue
+++ b/src/pages/History.vue
@@ -2,7 +2,7 @@
   <div class="mt2">
     <div v-if="allData.length > 0" class="center container-width">
       <media-item v-for="d in allData" :key="d.media.media_id" :id="d.media.media_id" :collectionName="d.collection.name" size="medium" />
-      <div class="f5 fw6 db ba b--black-20 bg-animate hover-bg-light-gray black br1 pointer pa3 tc more-btn box-shadow-umi" :class="[paginationLoading ? 'bg-light-gray' : 'bg-white']" @click="handlePagination">
+      <div class="f5 fw6 db ba b--black-20 bg-animate br1 pointer pa3 tc more-btn box-shadow-umi" :class="paginationClassList" @click="handlePagination">
         {{paginationLoading ? 'Loading...' : 'Load more'}}
       </div>
     </div>
@@ -31,7 +31,27 @@
     computed: {
       allData () {
         return this.$store.state.initialHistory.concat(this.data)
+      },
+      paginationClassList () {
+        if (this.paginationLoading) {
+          if(this.darkTheme) {
+            return ['bg-near-black', 'gray', 'hover-light-gray', 'hover-bg-dark-gray']
+          }
+          else {
+            return ['bg-light-gray', 'black', 'hover-bg-near-white']
+          }
+        } else {
+          if(this.darkTheme) {
+            return ['bg-black', 'gray', 'hover-bg-near-black']
+          } else {
+            return ['bg-white', 'black', 'hover-bg-light-gray']
+          }
+        }
+      },
+      darkTheme () {
+        return this.$store.state.darkTheme
       }
+      
     },
     components: {
       MediaItem,

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -12,6 +12,14 @@
         <div class="green mt1 absolute save-message" :class="[savedLocale ? 'o-100' : 'o-0']">Saved!</div>
       </div>
     </div>
+    <div class="cf">
+      <div class="fl mt2">
+        <span class="fw5">Dark theme</span>
+      </div>
+      <div class="fr">
+        <input type="checkbox" v-model="darkTheme" /> {{darkTheme ? 'On' : 'Off'}}
+      </div>
+    </div>
     <h2 class="fw5 bb pb2 b--dark-gray"><i class="fa fa-link mr1"></i> Connections</h2>
     <div class="cf">
       <div class="fl pv2">
@@ -56,6 +64,14 @@
       },
       locales () {
         return this.$store.state.locales
+      },
+      darkTheme: {
+        get () {
+          return this.$store.state.darkTheme
+        },
+        set (val) {
+          this.$store.commit('SET_DARK_THEME', val)
+        }
       }
     },
     watch: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -50,7 +50,8 @@ const store = new Vuex.Store({
     lights: false,
     error: false,
     expiredSession: '',
-    guestMessage: false
+    guestMessage: false,
+    darkTheme: false
   },
 
   actions: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -51,7 +51,7 @@ const store = new Vuex.Store({
     error: false,
     expiredSession: '',
     guestMessage: false,
-    darkTheme: false
+    darkTheme: localStorage.getItem('darkTheme') ? JSON.parse(localStorage.getItem('darkTheme')) : false
   },
 
   actions: {
@@ -545,6 +545,11 @@ const store = new Vuex.Store({
 
     SET_RECENT (state, arr) {
       Vue.set(state, 'recent', arr)
+    },
+
+    SET_DARK_THEME (state, bool) {
+      localStorage.setItem('darkTheme', bool)
+      Vue.set(state, 'darkTheme', bool)
     },
 
     ADD_SERIES (state, obj) {


### PR DESCRIPTION
the theme switch can be found in the settings page.

At the moment I just painted most of the things on screen black or dark-gray.
I also changed some existing styles to better fit the transformation.

At the moment I think it would be better to just refactor the classnames. So that instead of referring to `bg-white`  it would be `bg-primary` and `bg-near-white` to `bg-offset`.

overwriting styles using a "dark"  class on the root element and changing the component CSS files seems like a more attractive option after changing that.