### PR TITLE
Update extension and hide umi.party in requests

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,10 +1,26 @@
 /* global chrome */
 
-chrome.webRequest.onHeadersReceived.addListener(({responseHeaders}) => {
-  const corsHeader = responseHeaders.findIndex(({name}) => name.toLowerCase() === 'access-control-allow-origin')
-  if (corsHeader > -1) {
-    responseHeaders[corsHeader].value = '*'
-  }
+const urls = ['https://*.vrv.co/*', 'https://*.dlvr1.net/*', 'https://pl.crunchyroll.com/*']
+const origin = 'https://static.crunchyroll.com'
+const referer = 'https://static.crunchyroll.com/vilos-v2/web/vilos/no-referrer'
 
+function replaceHeader (headers, name, value) {
+  let index = headers.findIndex((header) => header.name.toLowerCase() === name)
+  if (index > -1) {
+    headers[index].value = value
+  } else {
+    headers.push({'name': name, 'value': value})
+  }
+  return headers
+}
+
+chrome.webRequest.onBeforeSendHeaders.addListener(({requestHeaders}) => {
+  replaceHeader(requestHeaders, 'origin', origin)
+  replaceHeader(requestHeaders, 'referer', referer)
+  return {requestHeaders}
+}, {'urls': urls}, ['blocking', 'requestHeaders'])
+
+chrome.webRequest.onHeadersReceived.addListener(({responseHeaders}) => {
+  replaceHeader(responseHeaders, 'access-control-allow-origin', '*')
   return {responseHeaders}
-}, {urls: ['https://*.vrv.co/*', 'https://*.dlvr1.net/*']}, ['blocking', 'responseHeaders'])
+}, {'urls': urls}, ['blocking', 'responseHeaders'])

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,7 +10,8 @@
     "webRequestBlocking",
     "https://umi.party/*",
     "https://*.vrv.co/*",
-    "https://*.dlvr1.net/*"
+    "https://*.dlvr1.net/*",
+	  "https://pl.crunchyroll.com/*"
   ],
 
   "background": {


### PR DESCRIPTION
I changed a few things in the extension that might be useful.

* Added pl.crunchyroll.com to list of domains (should hopefully fix the CORS issue #40)
* Requests to the URL list now change their Origin and Referer fields to match Crunchyroll's. This should help make the requests look identical to the requests the Crunchyroll website makes (and help avoid suspicion or notice from Crunchyroll).

Anything you want me to change or fix? Thank you for this project!