### PR TITLE
Fix pl.crunchyroll.com issue again

### DIFF
--- a/src/components/Video.vue
+++ b/src/components/Video.vue
@@ -39,12 +39,7 @@
     },
     computed: {
       streamUrl () {
-        const url = this.data.streams[0].url
-        if (url && url.includes('pl.crunchyroll.com')) {
-          return this.data.streams[0].url.replace('https://pl.crunchyroll.com', '/pl-proxy')
-        } else {
-          return this.data.streams[0].url
-        }
+        return this.data.streams[0].url
       },
       room () {
         return this.$store.state.roomId
@@ -73,6 +68,13 @@
         width: '1024px',
         height: '576px',
         source: this.streamUrl,
+        hlsjsConfig: {
+          xhrSetup: (xhr, url) => {
+            // use pl proxy whenever accessing pl.crunchyroll.com from hls.js
+            url = url.replace('https://pl.crunchyroll.com', '/pl-proxy');
+            xhr.open('GET', url, true);
+          }
+        },
         poster: this.poster,
         disableVideoTagContextMenu: true,
         plugins: [LevelSelector, Thumbnails],


### PR DESCRIPTION
This fixes #40 and #30 with how Crunchyroll is changing playlist URLs again. Previously they made pl.crunchyroll.com have playlists containing URLs to other domains without CORS so that using a simple proxy would work, but now they have these URLs inside of the playlists too, so it started breaking again because the playlists themselves weren't modified.

This commit will replace pl.crunchyroll.com URLs in HLS.js, so that it's replaced in playlists after they've been properly parsed.