### PR TITLE
FIX: Session destroyed on page refresh

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -133,7 +133,7 @@ export default {
         this.$route.name !== 'login' &&
         this.$route.name !== 'future-of-umi' &&
         Object.keys(this.$store.state.auth).length > 0 &&
-        (!this.$store.state.auth.token || !this.$store.state.auth.expires || new Date() > new Date(this.$store.state.auth.expires))
+        (!this.$store.state.auth.expires || new Date() > new Date(this.$store.state.auth.expires))
       ) {
         await this.$store.dispatch('logout', true)
         this.$router.replace(`/login?next=${encodeURIComponent(this.$route.fullPath)}`)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -86,7 +86,7 @@ const store = new Vuex.Store({
           commit('UPDATE_AUTH', {
             session_id: data.session_id,
             country: data.country_code.toLowerCase(),
-            token: data.auth,
+            token: data.auth || state.auth.token,
             expires: data.expires
           })
           resolve()


### PR DESCRIPTION
From @yowkah: Related to #50 . It seems that the Token is not always given with authentication. Absence of the token should not be valid reason to terminate or remove a perfectly good session.

